### PR TITLE
chore(ci): update Node.js matrix to 24/25

### DIFF
--- a/.agent/docs/tasks/v0.1.3-tasks.md
+++ b/.agent/docs/tasks/v0.1.3-tasks.md
@@ -1,0 +1,22 @@
+# v0.1.3 Tasks — Technical Debt & Follow-ups
+
+## Goal
+Address technical debt and finish incomplete implementation TODOs discovered during v0.1.2 work.
+
+## Tasks
+
+- **Repository / API TODOs**
+  - [ ] Implement Cloudflare Workers API calls in `app/composables/useAuth.ts`
+  - [ ] Implement missing repository store API calls for tags and recipes (`app/stores/data/*` TODOs)
+
+- **UI / UX**
+  - [ ] Implement global loading states in `app/stores/pages/recipes.ts`
+  - [ ] Implement NuxtUI toast integration in `app/composables/useAppToast.ts`
+  - [ ] Confirmation dialog where TODO present in `app/pages/index.vue`
+
+- **Maintenance**
+  - [ ] Triage and convert remaining `TODO` comments into Issues with owners and estimates
+  - [ ] Schedule follow-up sprint for v0.1.3
+
+## Timeline
+- Target: v0.1.3 (next sprint)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        # Use current Active LTS and Current for CI
+        node-version: [24, 25]
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "tsumi-meshi",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",


### PR DESCRIPTION
Update CI Node.js matrix to use Node 24 (Active LTS) and Node 25 (Current). Add engines.node >=24 to package.json. Ran local lint/typecheck/tests successfully. This PR targets release/v0.1.2 per release branch maintenance.